### PR TITLE
Updated to support Apple's new Binary Interface and Notification Format

### DIFF
--- a/lib/push-apns/version.rb
+++ b/lib/push-apns/version.rb
@@ -1,3 +1,3 @@
 module PushApns
-  VERSION = "1.0.4"
+  VERSION = "1.1"
 end

--- a/lib/push/apns/binary_notification_validator.rb
+++ b/lib/push/apns/binary_notification_validator.rb
@@ -6,6 +6,19 @@ module Push
         if record.payload_size > 256
           record.errors[:base] << "APN notification cannot be larger than 256 bytes. Try condensing your alert and device attributes."
         end
+        
+        if ([5, 10].include?(record.priority)) == false
+          record.errors[:prioritiy] << "APN priority must be 5 or 10."
+        end
+        
+        if record.alert.nil? && 
+           record.badge.nil? && 
+           record.sound.nil? && 
+           record.expiry.nil? && 
+           record.content_available.present? && 
+           record.priority == 10
+           record.errors[:priority] << "APN priority cannot be 10 for a push that contains only the content_available key."
+        end
       end
     end
   end

--- a/lib/push/message_apns.rb
+++ b/lib/push/message_apns.rb
@@ -11,6 +11,7 @@ module Push
       6 => "Missing topic size",
       7 => "Missing payload size",
       8 => "Invalid token",
+      10 => "Shutdown",
       255 => "None (unknown error)"
     }
     store :properties, accessors: [:alert, :badge, :sound, :expiry, :attributes_for_device, :content_available, :priority]


### PR DESCRIPTION
Updated to support Apple's new Binary Interface and Notification Format : https://developer.apple.com/library/mac/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/CommunicatingWIthAPS.html#//apple_ref/doc/uid/TP40008194-CH101-SW4
